### PR TITLE
Fixes inability to remove untagged Docker images.

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -3795,7 +3795,7 @@ def dangling(prune=False, force=False):
     '''
     all_images = images(all=True)
     dangling_images = [x[:12] for x in _get_top_level_images(all_images)
-                       if '<none>:<none>' in all_images[x]['RepoTags']]
+                       if all_images[x]['RepoTags'] is None]
     if not prune:
         return dangling_images
 


### PR DESCRIPTION
### What does this PR do?
This fixes the inability to remove untagged Docker images.

### Previous Behavior
Instead of removing the untagged Docker images, the following error would be returned when running `salt-call dockerng.dangling prune=True force=True -l debug`

```
Passed invalid arguments: argument of type 'NoneType' is not iterable.
Usage:
    Return top-level images (those on which no other images depend) which do
    not have a tag assigned to them. These include:
    - Images which were once tagged but were later untagged, such as those
      which were superseded by committing a new copy of an existing tagged
      image.
    - Images which were loaded using :py:func:`docker.load
      <salt.modules.dockerng.load>` (or the ``docker load`` Docker CLI
      command), but not tagged.
    prune : False
        Remove these images
    force : False
        If ``True``, and if ``prune=True``, then forcibly remove these images.
    **RETURN DATA**
    If ``prune=False``, the return data will be a list of dangling image IDs.
    If ``prune=True``, the return data will be a dictionary with each key being
    the ID of the dangling image, and the following information for each image:
    - ``Comment`` - Any error encountered when trying to prune a dangling image
      *(Only present if prune failed)*
    - ``Removed`` - A boolean (``True`` if prune was successful, ``False`` if
      not)
    CLI Example:
    .. code-block:: bash
        salt myminion dockerng.dangling
        salt myminion dockerng.dangling prune=True
    
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/cli/caller.py", line 197, in call
    ret['return'] = func(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/modules/dockerng.py", line 3612, in dangling
    if '<none>:<none>' in all_images[x]['RepoTags']]
```

### New Behavior
The appropriate Docker images are removed.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

